### PR TITLE
Add support for Gov and Japan Control Plane

### DIFF
--- a/src/README/citrix_system_log_add_on_settings.conf.spec
+++ b/src/README/citrix_system_log_add_on_settings.conf.spec
@@ -5,3 +5,4 @@ loglevel =
 customer_id = 
 client_id = 
 client_secret = 
+cloud_environment = 

--- a/src/appserver/static/js/build/globalConfig.json
+++ b/src/appserver/static/js/build/globalConfig.json
@@ -100,6 +100,29 @@
                                     "errorMsg": "Max length of password is 8192"
                                 }
                             ]
+                        },
+                        {
+                            "field": "cloud_environment",
+                            "label": "Cloud Environment",
+                            "type": "singleSelect",
+                            "options": {
+                                "disableSearch": true,
+                                "autoCompleteFields": [
+                                    {
+                                        "label": "Commercial",
+                                        "value": ".net"
+                                    },
+                                    {
+                                        "label": "Government",
+                                        "value": ".us"
+                                    },
+                                    {
+                                        "label": "Japan",
+                                        "value": ".jp"
+                                    }
+                                ]
+                            },
+                            "defaultValue": ".net"
                         }
                     ]
                 }

--- a/src/bin/citrix_system_log_add_on_rh_settings.py
+++ b/src/bin/citrix_system_log_add_on_rh_settings.py
@@ -55,6 +55,13 @@ fields_additional_parameters = [
             min_len=0, 
             max_len=8192, 
         )
+    ),
+    field.RestField(
+        'cloud_environment',
+        required=False,
+        encrypted=False,
+        default='.net',
+        validator=None
     )
 ]
 model_additional_parameters = RestModel(fields_additional_parameters, name='additional_parameters')


### PR DESCRIPTION
Adding a configuration option to select Commercial, Government or Japan.  api.cloud.com is only available in commercial so adding check to use systemlogs endpoint for Gov and Japan.